### PR TITLE
Drop the `gcc` package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,10 @@ env:
 
 
 before_install:
+    # Remove homebrew.
     - brew remove --force $(brew list)
+    - brew cleanup -s
+    - rm -rf $(brew --cache)
 
 install:
     - |
@@ -23,7 +26,7 @@ install:
 
       conda config --set show_channel_urls true
       conda update --yes conda
-      conda install --yes conda-build jinja2 anaconda-client
+      conda install --yes conda-build=1.20.0 jinja2 anaconda-client
       conda config --add channels conda-forge
       
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,18 +11,14 @@ source:
   sha256: 774980d027c52947cb9ee4fac6ffe2ca60cc2f753068a89dfd281c83dbff9651
 
 build:
-  number: 0
+  number: 1
   skip: true  # [win]
 
 requirements:
   build:
-    - gcc  # [linux]
     - autoconf
     - automake
     - m4
-
-  run:
-    - libgcc  # [linux]
 
 test:
   commands:


### PR DESCRIPTION
Fixes https://github.com/conda-forge/libsigcpp-feedstock/issues/3

Drops the `gcc` package and uses the compiler in the docker image, which is currently devtoolset-2. However, that may change in the future.

Also, re-rendered with `conda-smithy` 0.9.2.
